### PR TITLE
Projects page fixes

### DIFF
--- a/src/components/projects.js
+++ b/src/components/projects.js
@@ -17,15 +17,15 @@ const Projects = () => (
         <div className="project-block" key={index}>
           <a className="project-title" href={link}>{title}</a>
           {dates && <div className="project-dates">{dates}</div>}
-          <div className="text-block">{text}</div>
-          <a className="pic-wrapper" href={link}>
-            <img className="project-image" src={imgLink}/>
-          </a>
           <div className="project-links">
             {sourceLink && <a href={sourceLink}> SOURCE </a>}
             {link && sourceLink && <span>/</span>}
             {link && <a href={link}> LIVE </a>}
           </div>
+          <div className="text-block">{text}</div>
+          <a className="pic-wrapper" href={link}>
+            <img className="project-image" src={imgLink}/>
+          </a>
         </div>
       );
     })}

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -78,15 +78,14 @@ body,
   font-family: Roboto-Light, sans-serif;
   font-size: 14px;
   width: 100%;
+  padding-top: 14px;
 }
 
 .pic-wrapper {
   align-items: center;
   display: flex;
-  height: 100%;
   justify-content: center;
   min-height: 200px;
-  width: 100%;
 
   .profpic {
     background: url('https://s3-us-west-1.amazonaws.com/mcnutt-static-images/profpic.jpeg');


### PR DESCRIPTION
hey :wave: !

This fixes a couple of things I noticed about the [projects](https://www.mcnutt.in/#/projects) page.

I've moved the project links up to below the dates. Also to stop the images overflowing, I've removed the `height: 100%` and `width: 100%` from the css. Finally, I added a bit of padding to the top of the text body.

## New
![image](https://user-images.githubusercontent.com/13941027/48672625-3847fe80-eb30-11e8-90a1-ec6232682b10.png)

## Old
![image](https://user-images.githubusercontent.com/13941027/48672637-5ada1780-eb30-11e8-9862-78b57aff35b0.png)
